### PR TITLE
Upgrade Log4j2 from 2.10.0 to 2.18.0

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
@@ -188,7 +188,7 @@ public class TestOperationLoggingLayout {
     Map<String, Appender> appendersMap = loggerConfig.getAppenders();
     RoutingAppender routingAppender = (RoutingAppender) appendersMap.get(routingAppenderName);
     Assert.assertNotNull(msg + "could not find routingAppender " + routingAppenderName, routingAppender);
-    Field defaultsField = RoutingAppender.class.getDeclaredField("appenders");
+    Field defaultsField = RoutingAppender.class.getDeclaredField("createdAppenders");
     defaultsField.setAccessible(true);
     ConcurrentHashMap appenders = (ConcurrentHashMap) defaultsField.get(routingAppender);
     AppenderControl appenderControl = (AppenderControl) appenders.get(queryId);
@@ -219,7 +219,7 @@ public class TestOperationLoggingLayout {
     Map<String, Appender> appendersMap = loggerConfig.getAppenders();
     RoutingAppender routingAppender = (RoutingAppender) appendersMap.get(routingAppenderName);
     Assert.assertNotNull("could not find routingAppender " + routingAppenderName, routingAppender);
-    Field defaultsField = RoutingAppender.class.getDeclaredField("appenders");
+    Field defaultsField = RoutingAppender.class.getDeclaredField("createdAppenders");
     defaultsField.setAccessible(true);
     ConcurrentHashMap appenders = (ConcurrentHashMap) defaultsField.get(routingAppender);
     AppenderControl appenderControl = (AppenderControl) appenders.get(queryId);

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <kryo.version>3.0.3</kryo.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.10.0</log4j2.version>
+    <log4j2.version>2.12.1</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.5.8</orc.version>
     <mockito-all.version>1.10.19</mockito-all.version>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <kryo.version>3.0.3</kryo.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.12.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
     <orc.version>1.5.8</orc.version>
     <mockito-all.version>1.10.19</mockito-all.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -135,6 +135,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
     </dependency>

--- a/ql/src/java/org/apache/hadoop/hive/ql/log/SlidingFilenameRolloverStrategy.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/SlidingFilenameRolloverStrategy.java
@@ -73,6 +73,10 @@ public class SlidingFilenameRolloverStrategy
     return getLogFileName(pattern);
   }
 
+  @Override public void clearCurrentFileName() {
+    // no rename is needed
+  }
+
   /**
    * @return Mangled file name formed by appending the current timestamp
    */

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -78,7 +78,7 @@
     <junit.version>4.11</junit.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.8.2</log4j2.version>
+    <log4j2.version>2.12.1</log4j2.version>
     <mockito-all.version>1.10.19</mockito-all.version>
     <orc.version>1.5.1</orc.version>
     <protobuf.version>2.5.0</protobuf.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -264,6 +264,11 @@
       <version>${log4j2.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+   </dependency>
+    <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libfb303</artifactId>
       <version>${libfb303.version}</version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -78,13 +78,12 @@
     <junit.version>4.11</junit.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.9.3</libthrift.version>
-    <log4j2.version>2.12.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <mockito-all.version>1.10.19</mockito-all.version>
     <orc.version>1.5.1</orc.version>
     <protobuf.version>2.5.0</protobuf.version>
     <sqlline.version>1.3.0</sqlline.version>
     <storage-api.version>2.7.0</storage-api.version>
-
     <!-- Thrift properties -->
     <thrift.home>you-must-set-this-to-run-thrift</thrift.home>
     <thrift.gen.dir>${basedir}/src/gen/thrift</thrift.gen.dir>

--- a/testutils/ptest2/pom.xml
+++ b/testutils/ptest2/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <name>hive-ptest</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j2.version>2.10.0</log4j2.version>
+    <log4j2.version>2.12.1</log4j2.version>
     <spring.framework.version>3.2.16.RELEASE</spring.framework.version>
     <jclouds.version>2.0.0</jclouds.version>
     <checkstyle.conf.dir>${basedir}/../../checkstyle/</checkstyle.conf.dir>

--- a/testutils/ptest2/pom.xml
+++ b/testutils/ptest2/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   <name>hive-ptest</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j2.version>2.12.1</log4j2.version>
+    <log4j2.version>2.18.0</log4j2.version>
     <spring.framework.version>3.2.16.RELEASE</spring.framework.version>
     <jclouds.version>2.0.0</jclouds.version>
     <checkstyle.conf.dir>${basedir}/../../checkstyle/</checkstyle.conf.dir>


### PR DESCRIPTION
Fixes #2 

Applied Backports:
- https://github.com/apache/hive/commit/caf7ac0099645ac8500d824556941447e66e25e3
- https://github.com/apache/hive/commit/c9e7f5dd6191636232921279acc1a5dd5a6fcaff    